### PR TITLE
Added document level exit functions to the release method

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ function fullscreen(el) {
   }
 
   function release() {
+
+    var element_exit = 
     (el.exitFullscreen ||
     el.exitFullscreen ||
     el.webkitExitFullScreen ||
@@ -57,7 +59,28 @@ function fullscreen(el) {
     el.msExitFullScreen ||
     el.msExitFullscreen ||
     el.oExitFullScreen ||
-    el.oExitFullscreen).call(el)
+    el.oExitFullscreen);
+
+    if(element_exit) {
+      element_exit.call(el);
+      return;
+    }
+
+    var document_exit = 
+    (doc.exitFullscreen ||
+    doc.exitFullscreen ||
+    doc.webkitExitFullScreen ||
+    doc.webkitExitFullscreen ||
+    doc.mozExitFullScreen ||
+    doc.mozExitFullscreen ||
+    doc.msExitFullScreen ||
+    doc.msExitFullscreen ||
+    doc.oExitFullScreen ||
+    doc.oExitFullscreen);
+
+    document_exit.call(doc);
+
+
   } 
 
   function fullscreenelement() {


### PR DESCRIPTION
When using the package in Chrome 35 the release method was throwing an error since all the 'exitFullscreen' variations were undefined on the element.

Looking at the spec:

https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api

the exit methods appear to be on the document, not that element, and that works for me.

I've left the element level exit methods there in case they work for other browsers, if they are all undefined we then try the document level methods.
