### PR TITLE
Fix IE polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ function fullscreen(el) {
     , rfs = shim(el)
     , ee = new EE
 
-  var vendors = ['', 'webkit', 'moz', 'ms', 'o']
+    var vendors = ['', 'webkit', 'moz', 'ms', 'o'],
+        changeEventName,
+        errorEventName;
 
   for(var i = 0, len = vendors.length; i < len; ++i) {
     // if internet explorer
@@ -26,8 +28,8 @@ function fullscreen(el) {
         errorEventName = vendors[i] + 'fullscreenerror';
     }
 
-    ael.call(doc, vendors[i]+'fullscreenchange', onfullscreenchange)
-    ael.call(doc, vendors[i]+'fullscreenerror', onfullscreenerror)
+    ael.call(doc, changeEventName, onfullscreenchange)
+    ael.call(doc, errorEventName, onfullscreenerror)
   }
 
   ee.release = release

--- a/index.js
+++ b/index.js
@@ -17,6 +17,15 @@ function fullscreen(el) {
   var vendors = ['', 'webkit', 'moz', 'ms', 'o']
 
   for(var i = 0, len = vendors.length; i < len; ++i) {
+    // if internet explorer
+    if (i === 3) {
+        changeEventName = 'MSFullscreenChange';
+        errorEventName = 'MSFullscreenError';
+    } else {
+        changeEventName = vendors[i] + 'fullscreenchange';
+        errorEventName = vendors[i] + 'fullscreenerror';
+    }
+
     ael.call(doc, vendors[i]+'fullscreenchange', onfullscreenchange)
     ael.call(doc, vendors[i]+'fullscreenerror', onfullscreenerror)
   }


### PR DESCRIPTION
This should fix the unique prefixing and camel casing for the `fullscreenchange` and `fullscreenerror` events in IE, documented here: https://msdn.microsoft.com/en-us/library/ie/dn265028%28v=vs.85%29.aspx