### PR TITLE
Pass arguments to `*FullScreen` methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function fullscreen(el) {
   }
 
   function request() {
-    return rfs.call(el)
+    return rfs.apply(el, arguments)
   }
 
   function release() {
@@ -67,7 +67,7 @@ function fullscreen(el) {
     el.oExitFullscreen);
 
     if(element_exit) {
-      element_exit.call(el);
+      element_exit.apply(el, arguments);
       return;
     }
 
@@ -85,7 +85,7 @@ function fullscreen(el) {
     doc.oExitFullScreen ||
     doc.oExitFullscreen);
 
-    document_exit.call(doc);
+    document_exit.apply(doc, arguments);
 
 
   } 


### PR DESCRIPTION
As part of WebVR, you can call `requestFullscreen` with an extra argument (`{vrDisplay: vrHMD}`) which will format the screen to automatically distort the element with respect to the VR device's properties. This patch allows for any number of arguments to be passed on to the original `*fullScreen` methods.

Note: WebVR is still experimental, and is only available in nightly browsers. However, these changes shouldn't have a detrimental effect (i.e. non-breaking).

Note 2: AFAIK, the optional argument is only present in `requestFullscreen`, but since it's non-breaking, and future proofs any changes to the Fullscreen API spec (with regard to passing in arguments), I figured it's not a bad idea to add it to all the main methods.