### PR TITLE
Add fullscreen.enabled()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ fs.on('error', function() {
 
 return a boolean yes/no for whether fullscreen api is supported.
 
+## require('fullscreen').enabled() -> bool
+
+return a boolean yes/no for whether fullscreen is enabled for the document.
+
 ## fullscreen(element) -> fs event emitter
 
 return a fullscreen event emitter object. if fullscreen is not

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = fullscreen
 fullscreen.available = available
+fullscreen.enabled = enabled
 
 var EE = require('events').EventEmitter
 var ael = require('add-event-listener')
@@ -7,6 +8,13 @@ var rel = ael.removeEventListener
 
 function available() {
   return !!shim(document.body)
+}
+
+function enabled() {
+  return !!(document.fullscreenEnabled ||
+    document.webkitFullscreenEnabled ||
+    document.mozFullscreenEnabled ||
+    document.msFullscreenEnabled);
 }
 
 function fullscreen(el) {


### PR DESCRIPTION
This adds support for checking if fullscreen is enabled (which is more than simply checking if the API is supported and available).  One example of when this differs is this will return false when an iframe does not have the `allowfullscreen` attribute.

More details:
https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
https://fullscreen.spec.whatwg.org/#fullscreen-enabled-flag

Let me know if you'd like me to add more clarifying detail to the README!