### PR TITLE
Fix typo in mozFullScreenEnabled that caused enabled to return false in Firefox 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function available() {
 function enabled() {
   return !!(document.fullscreenEnabled ||
     document.webkitFullscreenEnabled ||
-    document.mozFullscreenEnabled ||
+    document.mozFullScreenEnabled ||
     document.msFullscreenEnabled);
 }
 
@@ -80,7 +80,7 @@ function fullscreen(el) {
       doc.msExitFullscreen);
 
     document_exit.apply(doc, arguments);
-  } 
+  }
 
   function fullscreenelement() {
     return (0 ||


### PR DESCRIPTION
The issue is that the `fullscreen.enabled` function would return `false` because `document.mozFullscreenEnabled` is `undefined` whereas `document.mozFullScreenEnabled` is the exact name of it.