### PR TITLE
Fix `enabled` functions api check

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ function fullscreen(el) {
       doc.mozExitFullScreen ||
       doc.msExitFullscreen);
 
-    document_exit.apply(doc, arguments);
+    if (enabled()) {
+      document_exit.apply(doc, arguments);
+    }
   } 
 
   function fullscreenelement() {

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ function available() {
 }
 
 function enabled() {
-  return !!(document.fullscreenEnabled ||
-    document.webkitFullscreenEnabled ||
-    document.mozFullScreenEnabled ||
-    document.msFullscreenEnabled);
+  return !!(document.fullscreenElement ||
+    document.webkitFullscreenElement ||
+    document.mozFullScreenElement ||
+    document.msFullscreenElement);
 }
 
 function fullscreen(el) {


### PR DESCRIPTION
Fixes #16

The `enabled` function is used to check if fullscreen is currently active or not, but is using the `fullscreenEnabled` function from the fullscreen API, which actually just checks if fullscreen is available or not. This merge changes the function to use `fullscreenElement` which will return an element if currently in fullscreen, or null if not.